### PR TITLE
Add CoinMarketCap implementation of ApiFetcher

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,10 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+
+    // For fetching the JSON
+    implementation 'com.squareup.retrofit2:retrofit:2.4.0'
+
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile "org.mockito:mockito-core:2.+"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,11 @@ repositories {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    compile 'com.google.code.gson:gson:2.8.2'
 
     // For fetching the JSON
     implementation 'com.squareup.retrofit2:retrofit:2.4.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.4.0'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile "org.mockito:mockito-core:2.+"

--- a/src/main/kotlin/latesco/network/abs/ApiFetcher.kt
+++ b/src/main/kotlin/latesco/network/abs/ApiFetcher.kt
@@ -19,6 +19,11 @@ package latesco.network.abs
 
 interface ApiFetcher {
 
+  val apiDomain: String
+  val refreshInterval: Long
+  var listener: ApiListener?
+  val registeredAssetUids: List<Long>
+
   /**
    * Update all assets register with this ApiFetcher.
    */
@@ -36,33 +41,4 @@ interface ApiFetcher {
    * Register an Asset with the ApiFetcher so it will be automatically updated.
    */
   fun registerAsset(assetUid: Long)
-
-  /**
-   * Register a callback listener with the ApiFetcher.
-   *
-   * This function will be called when registering an ApiFetcher with Latesco. It
-   * should not be used anywhere else.
-   */
-  fun registerListener(listener: ApiListener)
-
-  /**
-   * Return a list of all registered assetUids
-   *
-   * @return List of registered Uids
-   */
-  fun getRegisteredUids(): List<Long>
-
-  /**
-   * Return the refresh interval, in seconds, for the ApiFetcher
-   *
-   * @return Refresh invterval in seconds
-   */
-  fun getRefreshInterval(): Long
-
-  /**
-   * Returns the domain of the ApiFetcher.
-   *
-   * This is used for ensuring uniqueness of an ApiFetcher during initialization.
-   */
-  fun getApiDomain(): String
 }

--- a/src/main/kotlin/latesco/network/abs/ApiListener.kt
+++ b/src/main/kotlin/latesco/network/abs/ApiListener.kt
@@ -17,6 +17,23 @@
 
 package latesco.network.abs
 
-interface ApiListener {
+import latesco.core.data.Asset
+import latesco.core.data.PriceRecord
 
+interface ApiListener {
+  /**
+   * Tell the Listener to record a new PriceRecord entry
+   *
+   * @param record    New PriceRecord
+   */
+  fun recordPrice(record: PriceRecord)
+
+  /**
+   * Return the Asset corresponding to a UID.
+   *
+   * @param uid   UID of Asset
+   *
+   * @return Asset matching the UID.
+   */
+  fun getAsset(uid: Long) : Asset
 }

--- a/src/main/kotlin/latesco/network/coinmarket/ApiResponse.kt
+++ b/src/main/kotlin/latesco/network/coinmarket/ApiResponse.kt
@@ -17,7 +17,6 @@
 
 package latesco.network.coinmarket
 
-import com.google.gson.annotations.SerializedName
 import java.math.BigDecimal
 
 /**
@@ -25,8 +24,4 @@ import java.math.BigDecimal
  *
  * Since this class is based on JSON, the naming conventions are different.
  */
-class ApiResponse(val id: String, val name: String, val symbol: String, val rank: Int, val price_usd: BigDecimal,
-    val price_btc: BigDecimal, @SerializedName("24h_volume_usd") val volume_usd: BigDecimal,
-    val market_cap_usd: BigDecimal, val available_supply: BigDecimal, val total_supply: BigDecimal,
-    val percent_change_1h: Double, val percent_change_24h: Double, val percent_change_7d: Double,
-    val last_updated: Long)
+class ApiResponse(val id: String, val name: String, val symbol: String, val price_usd: BigDecimal)

--- a/src/main/kotlin/latesco/network/coinmarket/ApiResponse.kt
+++ b/src/main/kotlin/latesco/network/coinmarket/ApiResponse.kt
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Latesco.
+ *
+ * Latesco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Latesco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Latesco.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package latesco.network.coinmarket
+
+import com.google.gson.annotations.SerializedName
+import java.math.BigDecimal
+
+/**
+ * Class representing a single crypto-currency response from Latesco. It is modeled directly from the JSON.
+ *
+ * Since this class is based on JSON, the naming conventions are different.
+ */
+class ApiResponse(val id: String, val name: String, val symbol: String, val rank: Int, val price_usd: BigDecimal,
+    val price_btc: BigDecimal, @SerializedName("24h_volume_usd") val volume_usd: BigDecimal,
+    val market_cap_usd: BigDecimal, val available_supply: BigDecimal, val total_supply: BigDecimal,
+    val percent_change_1h: Double, val percent_change_24h: Double, val percent_change_7d: Double,
+    val last_updated: Long)

--- a/src/main/kotlin/latesco/network/coinmarket/CoinMarketCapService.kt
+++ b/src/main/kotlin/latesco/network/coinmarket/CoinMarketCapService.kt
@@ -1,0 +1,33 @@
+/*
+ * This file is part of Latesco.
+ *
+ * Latesco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Latesco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Latesco.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package latesco.network.coinmarket
+
+import retrofit2.Call
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+const val coinMarketApi = "https://api.coinmarketcap.com/v1/"
+
+interface CoinMarketCapService {
+  @GET("ticker/")
+  fun getTickerAll() : Call<List<ApiResponse>>
+
+  @GET("ticker/{id}")
+  fun getTickerSpecific(@Path("id") id: String) : Call<List<ApiResponse>>
+}
+

--- a/src/main/kotlin/latesco/network/coinmarket/CoinMarketFetcher.kt
+++ b/src/main/kotlin/latesco/network/coinmarket/CoinMarketFetcher.kt
@@ -1,0 +1,108 @@
+/*
+ * This file is part of Latesco.
+ *
+ * Latesco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Latesco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Latesco.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package latesco.network.coinmarket
+
+import latesco.core.data.Asset
+import latesco.core.data.PriceRecord
+import latesco.network.abs.ApiFetcher
+import latesco.network.abs.ApiListener
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+/**
+ * An ApiFetcher implementation for retrieving crypto-currency prices from CoinMarketCap.
+ *
+ * @param refreshInterval   How often the fetcher should wait before adding a new price entry (in seconds)
+ */
+class CoinMarketFetcher(override val refreshInterval: Long) : ApiFetcher {
+
+  override val apiDomain: String
+    get() = coinMarketApi
+
+  override var listener: ApiListener? = null
+
+  override val registeredAssetUids: MutableList<Long> = mutableListOf()
+
+  private val service: CoinMarketCapService
+
+  init {
+    val rt = Retrofit.Builder()
+        .baseUrl(coinMarketApi)
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+
+    service = rt.create(CoinMarketCapService::class.java)
+  }
+
+  override fun update() {
+    if (listener == null) {
+      return
+    }
+
+    val listener = listener!!
+
+    val response = service.getTickerAll().execute()
+
+    if (response.isSuccessful) {
+      val results = response.body()!!
+
+      // For every registered Asset UID, find a match in the response
+      registeredAssetUids.forEach { uid ->
+        // This is guaranteed to exist since these UIDs are registered from the listener
+        val assetId = listener.getAsset(uid).name.toLowerCase()
+        val match: ApiResponse? = results.find { it.id == assetId }
+
+        if (match != null) {
+          listener.recordPrice(createPriceEntry(uid, match))
+        }
+      }
+    }
+  }
+
+  override fun manualUpdate(assetUid: Long) {
+    if (listener == null || !registeredAssetUids.contains(assetUid)) {
+      return
+    }
+
+    val listener = listener!!
+
+    val asset: Asset = listener.getAsset(assetUid)
+
+    // CoinMarketCap uses the lower case name as the id
+    val assetId = asset.name.toLowerCase()
+
+    val response = service.getTickerSpecific(assetId).execute()
+
+    if (response.isSuccessful) {
+      val result = response.body()
+
+      result?.forEach {
+        val record = createPriceEntry(assetUid, it)
+        listener.recordPrice(record)
+      }
+    }
+  }
+
+  private fun createPriceEntry(assetUid: Long, result: ApiResponse) : PriceRecord {
+    return PriceRecord(assetUid, 0, System.currentTimeMillis(), result.price_usd)
+  }
+
+  override fun registerAsset(assetUid: Long) {
+    registeredAssetUids.add(assetUid)
+  }
+}

--- a/src/test/kotlin/latesco/network/coinmarket/CoinMarketFetcherTest.kt
+++ b/src/test/kotlin/latesco/network/coinmarket/CoinMarketFetcherTest.kt
@@ -1,0 +1,125 @@
+/*
+ * This file is part of Latesco.
+ *
+ * Latesco is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Latesco is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Latesco.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package latesco.network.coinmarket
+
+import latesco.core.data.Asset
+import latesco.network.abs.ApiListener
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.mockito.Mockito
+
+class CoinMarketFetcherTest {
+
+  @Test
+  fun getApiDomain() {
+    val fetcher = CoinMarketFetcher(5)
+    assertEquals(coinMarketApi, fetcher.apiDomain)
+  }
+
+  @Test
+  fun getAndSetListener() {
+    val mockListener = Mockito.mock(ApiListener::class.java)
+
+    val fetcher = CoinMarketFetcher(0)
+
+    assertNull(fetcher.listener)
+
+    fetcher.listener = mockListener
+
+    assertNotNull(fetcher.listener)
+    assertEquals(mockListener, fetcher.listener)
+  }
+
+  @Test
+  fun getAndAddToRegisteredAssetUids() {
+    val fetcher = CoinMarketFetcher(0)
+
+    assertEquals(0, fetcher.registeredAssetUids.size)
+
+    fetcher.registerAsset(0)
+
+    assertEquals(1, fetcher.registeredAssetUids.size)
+    assertEquals(0, fetcher.registeredAssetUids[0])
+  }
+
+  @Test
+  fun update() {
+    var counter = 0
+    val bitcoinAsset = Asset(0, "Bitcoin", "BTC")
+    val ethereum = Asset(1, "Ethereum", "ETH")
+    val mockListener = Mockito.mock(ApiListener::class.java)
+
+    Mockito.`when`(mockListener.recordPrice(anyObject())).then { counter++}
+    Mockito.`when`(mockListener.getAsset(0)).thenReturn(bitcoinAsset)
+    Mockito.`when`(mockListener.getAsset(1)).thenReturn(ethereum)
+
+    val fetcher = CoinMarketFetcher(0)
+
+    fetcher.update()
+    assertEquals(0, counter)
+
+    fetcher.listener = mockListener
+
+    fetcher.registerAsset(bitcoinAsset.uid)
+
+    assertEquals(0, counter)
+    fetcher.update()
+    assertEquals(1, counter)
+
+    fetcher.registerAsset(ethereum.uid)
+    fetcher.update()
+    assertEquals(3, counter)
+  }
+
+  @Test
+  fun manualUpdate() {
+    var counter = 0
+    val bitcoinAsset = Asset(0, "Bitcoin", "BTC")
+    val mockListener = Mockito.mock(ApiListener::class.java)
+
+    Mockito.`when`(mockListener.recordPrice(anyObject())).then { counter++}
+    Mockito.`when`(mockListener.getAsset(0)).thenReturn(bitcoinAsset)
+
+    val fetcher = CoinMarketFetcher(0)
+
+    assertEquals(0, counter)
+    fetcher.manualUpdate(bitcoinAsset.uid)
+    fetcher.manualUpdate(-1)
+    assertEquals(0, counter)
+
+    fetcher.listener = mockListener
+    fetcher.registerAsset(bitcoinAsset.uid)
+
+    fetcher.manualUpdate(bitcoinAsset.uid)
+    assertEquals(1, counter)
+
+    fetcher.manualUpdate(-1)
+    assertEquals(1, counter)
+  }
+
+  @Test
+  fun getRefreshInterval() {
+    val fetcher = CoinMarketFetcher(5)
+    assertEquals(5, fetcher.refreshInterval)
+  }
+}
+
+private fun <T> anyObject(): T {
+  return Mockito.any<T>()
+}


### PR DESCRIPTION
Implemented an ApiFetcher for CoinMarketCap using Retrofit and GSON.

It handles manual updates of individual crypto-currencies and  bulk updates of registered assets.